### PR TITLE
Issue #9 Should fix Zend_Registry::setExists($index) issues with PHP7.4+

### DIFF
--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -194,16 +194,4 @@ class Zend_Registry extends ArrayObject
     {
         parent::__construct($array, $flags);
     }
-
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
-
 }


### PR DESCRIPTION
Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
